### PR TITLE
Fix export characters permissions and application did not respond errors

### DIFF
--- a/commands/db.py
+++ b/commands/db.py
@@ -3,8 +3,15 @@ from discord import app_commands
 import json
 import os
 import oracledb
+import yaml
 
 BACKUP_CHANNEL = 'npc-character-backup'
+
+def load_config():
+    with open("./db-info/config.yml", "r") as file:
+        return yaml.safe_load(file)
+
+config = load_config()
 
 def create_oracle_connection():
     connection = oracledb.connect(

--- a/commands/db.py
+++ b/commands/db.py
@@ -3,15 +3,8 @@ from discord import app_commands
 import json
 import os
 import oracledb
-import yaml
 
 BACKUP_CHANNEL = 'npc-character-backup'
-
-def load_config():
-    with open("./db-info/config.yml", "r") as file:
-        return yaml.safe_load(file)
-
-config = load_config()
 
 def create_oracle_connection():
     connection = oracledb.connect(
@@ -27,7 +20,11 @@ async def create_backup_channel(guild: discord.Guild):
 
     overwrites = {
         guild.default_role: discord.PermissionOverwrite(read_messages=False),
-        guild.me: discord.PermissionOverwrite(read_messages=True)
+        guild.me: discord.PermissionOverwrite(
+            read_messages=True,
+            send_messages=True, 
+            attach_files=True
+        )
     }
     channel = await guild.create_text_channel(BACKUP_CHANNEL, overwrites=overwrites)
     await channel.edit(topic="NPC-generated channel for storing character data backups.")
@@ -104,33 +101,38 @@ async def load_character_data(interaction: discord.Interaction, message: discord
         connection.close()
  
 @app_commands.command(name="export_characters_manual", description="Export the list of characters as JSON to the back up channel")
-async def export_characters_manual(interaction: discord.Interaction, send_messages: bool = True):
-    await export_characters(interaction, send_messages)
+async def export_characters_manual(interaction: discord.Interaction):
+    await interaction.response.defer(ephemeral=True)
+    await export_characters(interaction)
 
-async def export_characters(interaction, send_messages):
+async def export_characters(interaction: discord.Interaction):
     guild_id = str(interaction.guild_id)
+    
     connection = create_oracle_connection()
     cursor = connection.cursor()
+    
     cursor.execute('''
         SELECT character_name, owner_id, image_url, background, allowed_users
         FROM characters
         WHERE guild_id = :guild_id
     ''', {"guild_id": guild_id})
+    
     characters = cursor.fetchall()
+    
     if not characters or len(characters) == 0:
-        if send_messages:
-            await interaction.response.send_message("No characters to export.", ephemeral=True)
+        await interaction.response.send_message("No characters to export.", ephemeral=True)
         cursor.close()
         connection.close()
         return
 
     characters_data = {}
     for character in characters:
-        characters_data[character[0]] = {
-            "owner_id": character[1],
-            "image_url": character[2],
-            "background": character[3],
-            "allowed_users": json.loads(character[4].read())
+        character_name, owner_id, image_url, background, allowed_users = character
+        characters_data[character_name] = {
+            "owner_id": owner_id,
+            "image_url": image_url,
+            "background": background,
+            "allowed_users": json.loads(allowed_users.read())
         }
     cursor.close()
     connection.close()
@@ -138,8 +140,7 @@ async def export_characters(interaction, send_messages):
     private_channel = discord.utils.get(interaction.guild.text_channels, name=BACKUP_CHANNEL)
     if private_channel:
         await export_json_to_channel(private_channel, characters_data)
-        if send_messages:
-            await interaction.followup.send("Characters exported successfully.", ephemeral=True)
+        await interaction.followup.send("Characters exported successfully.", ephemeral=True)
     else:
         await interaction.followup.send("Backup channel not found. Please run /init", ephemeral=True)
 
@@ -149,4 +150,3 @@ async def export_json_to_channel(channel, data):
 
     await channel.send(file=discord.File("characters.json"))
     os.remove("characters.json")
-    


### PR DESCRIPTION
Fix export characters permissions and application did not respond errors
This PR fixes two issues:

Issue 1
The backup channel created in the /init command does not allow the Discord bot to send messages or upload files. This resulted in a 403 Forbidden error when the bot tried to upload the characters.json in export_characters.

Solution

This is fixed by granting the send_messages and attach_files permissions in the permission overwrites used to create the text channel in the init() method.

Issue 2
The command /export_characters_manual responds with Application did not respond when the parameter send_messages is set to False, even though the command succeeded and the data is posted to the backup channel. This makes it seem like something went wrong, even though everything went fine.

Solution

Remove the send_messages parameter and always respond. Discord does not allow a bot to give no response to a command.