### PR TITLE
Fix /view_character not working

### DIFF
--- a/commands/character.py
+++ b/commands/character.py
@@ -243,6 +243,7 @@ async def view_character(interaction: discord.Interaction, character_name: str):
         return
     
     channel = interaction.channel
-    await db.export_json_to_channel(channel, {[character_name]: character})
+    await db.export_json_to_channel(channel, {character_name: character})
     msg = await interaction.followup.send('Success!', ephemeral=True)
     await msg.delete(delay=2)
+    


### PR DESCRIPTION
Fixes an error that stops the /view_character command from running.

The issue was caused by a type error in the dictionary passed to db.export_json_to_channel().
```
discord.app_commands.errors.CommandInvokeError: Command 'view_character' raised an exception: TypeError: unhashable type: 'list'
```
This shouldn't be a list containing the character name, but rather the character name itself.